### PR TITLE
Remove Java >=15 guard case

### DIFF
--- a/hz.ps1
+++ b/hz.ps1
@@ -1309,15 +1309,6 @@ function ensure-java {
             `
             "--add-opens",   "java.base/java.io=ALL-UNNAMED" `
         )
-
-        # "Scripting is currently unsupported for Java 15 and newer. These versions
-        #  of Java do not come with a JavaScript engine, which is necessary for this
-        #  feature to work."
-        $pos = $javaVersion.IndexOf('.')
-        $javaMajor = $javaVersion.SubString(0, $pos)
-        if (-not ($javaVersion -lt "12") ) {
-            Die "Java version >11 not supported (JavaScript scripting not supported)"
-        }
 	}
 }
 


### PR DESCRIPTION
Now that [`hazelcast-remote-controller` supports Java 17](https://github.com/hazelcast/hazelcast-remote-controller/pull/69), the guard case preventing this can be removed.

Related [`client-compatibility-suites` PR](https://github.com/hazelcast/client-compatibility-suites/pull/88)